### PR TITLE
Fix NoneType when miner has no payment (yet)

### DIFF
--- a/flexpoolapi/minerapi.py
+++ b/flexpoolapi/minerapi.py
@@ -150,9 +150,10 @@ class MinerAPI:
         shared.check_response(api_request)
         api_request = api_request.json()["result"]
         classed_payments = []
-        for raw_tx in api_request["data"]:
-            classed_payments.append(Transaction(
-                raw_tx["amount"], raw_tx["timestamp"], raw_tx["duration"], raw_tx["txid"]))
+        if api_request["data"]:
+            for raw_tx in api_request["data"]:
+                classed_payments.append(Transaction(
+                    raw_tx["amount"], raw_tx["timestamp"], raw_tx["duration"], raw_tx["txid"]))
 
         return shared.PageResponse(
             classed_payments, api_request["total_items"], api_request["total_pages"], api_request["items_per_page"])


### PR DESCRIPTION
Recent miners don't have payment so the `payments_paged` method returns an error:

```
>>> import flexpoolapi
>>> miner = flexpoolapi.miner('0x3e2251567f87E4B6a3927158AF9c678ECa87a337')
>>> miner.payments_paged(page=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/flexpoolapi/minerapi.py", line 153, in payments_paged
    for raw_tx in api_request["data"]:
TypeError: 'NoneType' object is not iterable
```

Because `data` is None when there is no payment.

Big miners are ok:
```
>>> miner = flexpoolapi.miner('0x3D7193B546A12d287e54c1d6aaC3bf15B82bE59d')
>>> miner.payments_paged(page=0)
<flexpoolapi.shared.PageResponse object [<flexpoolapi.miner.Transaction object  2.09392 ETH (2021 Jan 25 07:39)>, <flexpoolapi.miner.Transaction object  2.05627 ETH (2021 Jan 25 02:39)>, <flexpoolapi.miner.Transaction object  2.30742 ETH (2021 Jan 24 10:02)>, <flexpoolapi.miner.Transaction object  2.51857 ETH (2021 Jan 23 06:13)>, <flexpoolapi.miner.Transaction object  2.32687 ETH (2021 Jan 22 08:22)>, <flexpoolapi.miner.Transaction object  23.11924 ETH (2021 Jan 21 16:34)>, <flexpoolapi.miner.Transaction object  2.2668 ETH (2021 Jan 21 02:54)>, <flexpoolapi.miner.Transaction object  2.32748 ETH (2021 Jan 20 09:45)>, <flexpoolapi.miner.Transaction object  2.30845 ETH (2021 Jan 18 15:16)>, <flexpoolapi.miner.Transaction object  2.77091 ETH (2021 Jan 18 07:29)>]>
```

With this commit, recent miners are able to use the `payments_paged` method:

```
>>> miner = flexpoolapi.miner('0x3e2251567f87E4B6a3927158AF9c678ECa87a337')
>>> miner.payments_paged(page=0)
<flexpoolapi.shared.PageResponse object []>
```