### PR TITLE
Remove hashrate from top donators

### DIFF
--- a/docs/pool.rst
+++ b/docs/pool.rst
@@ -153,15 +153,13 @@ Top Statistics
          >>> top_donators[0]
          <flexpoolapi.pool.TopDonator object 0xD7557BcC922E16D5248231Ee85919F5b01c97d12: 534.1283 ETH>
 
-         >>> top_miners[0].address
+         >>> top_donators[0].address
          0xD7557BcC922E16D5248231Ee85919F5b01c97d12
-         >>> top_miners[0].hashrate
-         4832143791236
-         >>> top_miners[0].pool_donation
+         >>> top_donators[0].pool_donation
          0.05
-         >>> top_miners[0].total_donated
+         >>> top_donators[0].total_donated
          534.128394767847103826
-         >>> top_miners[0].first_joined
+         >>> top_donators[0].first_joined
          datetime.datetime(2020, 5, 13, 20, 8, 7)
 
       **References:**

--- a/flexpoolapi/poolapi.py
+++ b/flexpoolapi/poolapi.py
@@ -64,11 +64,10 @@ class TopMiner:
 
 class TopDonator:
     def __init__(self,
-                 address: str, total_donated: int, pool_donation: float, hashrate: int, first_joined_timestamp: int):
+                 address: str, total_donated: int, pool_donation: float, first_joined_timestamp: int):
         self.address = address
         self.total_donated = total_donated
         self.pool_donation = pool_donation
-        self.hashrate = hashrate
         self.first_joined = datetime.datetime.fromtimestamp(
             first_joined_timestamp)
 
@@ -166,7 +165,6 @@ class PoolAPI:
                     top_donator["address"],
                     top_donator["total_donated"],
                     top_donator["pool_donation"],
-                    top_donator["hashrate"],
                     top_donator["first_joined"]
                 )
             )

--- a/tests/simdata.py
+++ b/tests/simdata.py
@@ -139,7 +139,6 @@ for i in range(0, 10):
         "address": utils.genrandaddr(),
         "total_donated": total_donated_top[i],
         "pool_donation": random.choice([0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1]),
-        "hashrate": random.randint(1000000000, 15000000000),
         "first_joined": random.randint(int(time.time()) - 86400 * 365, int(time.time()))
     })
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -110,7 +110,6 @@ class TestPool:
             assert top_miner["address"] == got[i].address
             assert top_miner["total_donated"] == got[i].total_donated
             assert top_miner["pool_donation"] == got[i].pool_donation
-            assert top_miner["hashrate"] == got[i].hashrate
             assert top_miner["first_joined"] == got[i].first_joined.timestamp()
 
     def test_avg_luck_roundtime(self):

--- a/tests/test_pool_sim.py
+++ b/tests/test_pool_sim.py
@@ -89,7 +89,6 @@ class TestPoolSimulated:
             assert expected_miner["address"] == got[i].address
             assert expected_miner["total_donated"] == got[i].total_donated
             assert expected_miner["pool_donation"] == got[i].pool_donation
-            assert expected_miner["hashrate"] == got[i].hashrate
             assert expected_miner["first_joined"] == got[i].first_joined.timestamp(
             )
 


### PR DESCRIPTION
Tests were failing because "hashrate" is absent from the top donator API call.

Before:
```
root@e99486b264a5:/mnt/tests# pytest .
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.7.8, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /mnt
collected 59 items                                                                                                                                                                        

test_local.py .....                                                                                                                                                                 [  8%]
test_miner_sim.py ................                                                                                                                                                  [ 35%]
test_misc.py .......                                                                                                                                                                [ 47%]
test_pool.py ...........                                                                                                                                                            [ 66%]
test_pool_sim.py ...........                                                                                                                                                        [ 84%]
test_utils.py .....                                                                                                                                                                 [ 93%]
test_worker_sim.py ....                                                                                                                                                             [100%]

=================================================================================== 59 passed in 8.53s ====================================================================================
root@e99486b264a5:/mnt/tests# ^C
root@e99486b264a5:/mnt/tests# ^C
root@e99486b264a5:/mnt/tests# pytest .
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.7.8, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /mnt
collected 59 items                                                                                                                                                                        

test_local.py .....                                                                                                                                                                 [  8%]
test_miner_sim.py ................                                                                                                                                                  [ 35%]
test_misc.py .......                                                                                                                                                                [ 47%]
test_pool.py ........F..                                                                                                                                                            [ 66%]
test_pool_sim.py ...........                                                                                                                                                        [ 84%]
test_utils.py .....                                                                                                                                                                 [ 93%]
test_worker_sim.py ....                                                                                                                                                             [100%]

======================================================================================== FAILURES =========================================================================================
_______________________________________________________________________________ TestPool.test_top_donators ________________________________________________________________________________

self = <tests.test_pool.TestPool object at 0x7f6758ca6e10>

    def test_top_donators(self):
        expected = requests.get(
            "https://flexpool.io/api/v1/pool/topDonators").json()["result"]
>       got = flexpoolapi.pool.top_donators()

test_pool.py:108: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <flexpoolapi.poolapi.PoolAPI object at 0x7f6758cd7f50>

    def top_donators(self):
        api_request = requests.get(self.endpoint + "/topDonators/")
        shared.check_response(api_request)
        top_donators_classed = []
        for top_donator in api_request.json()["result"]:
            top_donators_classed.append(
                TopDonator(
                    top_donator["address"],
                    top_donator["total_donated"],
                    top_donator["pool_donation"],
>                   top_donator["hashrate"],
                    top_donator["first_joined"]
                )
            )
E           KeyError: 'hashrate'

../flexpoolapi/poolapi.py:169: KeyError
================================================================================= short test summary info =================================================================================
FAILED test_pool.py::TestPool::test_top_donators - KeyError: 'hashrate'
============================================================================== 1 failed, 58 passed in 8.25s ===============================================================================
```

With this commit:
```
root@e99486b264a5:/mnt/tests# pytest .
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.7.8, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /mnt
collected 59 items                                                                                                                                                                        

test_local.py .....                                                                                                                                                                 [  8%]
test_miner_sim.py ................                                                                                                                                                  [ 35%]
test_misc.py .......                                                                                                                                                                [ 47%]
test_pool.py ...........                                                                                                                                                            [ 66%]
test_pool_sim.py ...........                                                                                                                                                        [ 84%]
test_utils.py .....                                                                                                                                                                 [ 93%]
test_worker_sim.py ....                                                                                                                                                             [100%]

=================================================================================== 59 passed in 8.75s ====================================================================================
```